### PR TITLE
Fix provider authentication flows

### DIFF
--- a/src/pages/settings/ProviderLoginDialog.scss
+++ b/src/pages/settings/ProviderLoginDialog.scss
@@ -1,0 +1,163 @@
+.provider-login-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1em;
+  box-sizing: border-box;
+  background-color: rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
+
+.provider-login-dialog {
+  width: min(34em, 100%);
+  max-height: min(80vh, 42em);
+  overflow-y: auto;
+  box-sizing: border-box;
+  padding: 1em;
+  color: var(--eca-input-fg);
+  background-color: var(--eca-panel-bg, var(--eca-base-bg));
+  border: 1px solid var(--eca-panel-border, var(--eca-base-border));
+  border-radius: 0.6em;
+  box-shadow: 0 0.8em 2.4em rgba(0, 0, 0, 0.35);
+}
+
+.provider-login-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1em;
+  margin-bottom: 0.9em;
+
+  h3 {
+    margin: 0;
+    font-size: 1.05em;
+  }
+
+  p {
+    margin: 0.35em 0 0;
+    color: var(--eca-input-placeholder-fg);
+    font-size: 0.88em;
+    line-height: 1.4;
+  }
+}
+
+.provider-login-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3em;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  border-radius: 0.3em;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background-color: color-mix(in srgb, currentColor 12%, transparent);
+  }
+}
+
+.provider-login-methods {
+  display: grid;
+  gap: 0.55em;
+
+  button {
+    padding: 0.65em 0.8em;
+    color: var(--eca-input-fg);
+    text-align: left;
+    background-color: var(--eca-input-bg);
+    border: 1px solid var(--eca-base-border);
+    border-radius: 0.4em;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+      border-color: var(--eca-link-fg);
+    }
+  }
+}
+
+.provider-login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75em;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3em;
+    font-size: 0.85em;
+  }
+
+  input {
+    box-sizing: border-box;
+    width: 100%;
+    padding: 0.55em 0.65em;
+    color: var(--eca-input-fg);
+    background-color: var(--eca-input-bg);
+    border: 1px solid var(--eca-base-border);
+    border-radius: 0.35em;
+    outline: none;
+
+    &:focus {
+      border-color: var(--eca-link-fg);
+    }
+  }
+}
+
+.provider-login-device-code {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35em;
+  margin: 1em 0;
+  color: var(--eca-input-placeholder-fg);
+  font-size: 0.82em;
+
+  code {
+    padding: 0.45em 0.75em;
+    color: var(--eca-input-fg);
+    font-size: 1.45em;
+    letter-spacing: 0.12em;
+    background-color: var(--eca-input-bg);
+    border: 1px solid var(--eca-base-border);
+    border-radius: 0.35em;
+    user-select: all;
+  }
+}
+
+.provider-login-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5em;
+  margin-top: 0.9em;
+
+  button {
+    padding: 0.4em 0.8em;
+    color: var(--eca-input-fg);
+    background: transparent;
+    border: 1px solid var(--eca-base-border);
+    border-radius: 0.35em;
+    cursor: pointer;
+
+    &.primary {
+      color: var(--eca-button-primary-fg);
+      background-color: var(--eca-button-primary-bg);
+      border-color: var(--eca-button-primary-border);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+  }
+}
+
+.provider-login-error {
+  margin: 0.8em 0 0;
+  color: var(--eca-error-fg);
+  font-size: 0.85em;
+}

--- a/src/pages/settings/ProviderLoginDialog.tsx
+++ b/src/pages/settings/ProviderLoginDialog.tsx
@@ -1,0 +1,157 @@
+import { FormEvent, useEffect, useRef, useState } from 'react';
+import { InputField, LoginAction, LoginMethod } from '../../protocol';
+import './ProviderLoginDialog.scss';
+
+export type ActiveLoginAction = Exclude<LoginAction, { action: 'done' }>;
+
+interface ProviderLoginDialogProps {
+    providerName: string;
+    action: ActiveLoginAction;
+    busy: boolean;
+    error: string | null;
+    onChooseMethod: (method: LoginMethod) => void;
+    onSubmitFields: (data: Record<string, string>) => void;
+    onClose: () => void;
+}
+
+function actionFields(action: ActiveLoginAction): InputField[] {
+    if (action.action === 'input') return action.fields;
+    if (action.action === 'authorize') return action.fields ?? [];
+    return [];
+}
+
+function initialValues(fields: InputField[]): Record<string, string> {
+    return Object.fromEntries(fields.map(field => [field.key, '']));
+}
+
+export function ProviderLoginDialog({
+    providerName,
+    action,
+    busy,
+    error,
+    onChooseMethod,
+    onSubmitFields,
+    onClose,
+}: ProviderLoginDialogProps) {
+    const fields = actionFields(action);
+    const [values, setValues] = useState<Record<string, string>>(() => initialValues(fields));
+    const firstInputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        const nextFields = actionFields(action);
+        setValues(initialValues(nextFields));
+        if (nextFields.length > 0) {
+            requestAnimationFrame(() => firstInputRef.current?.focus());
+        }
+    }, [action]);
+
+    const submit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!busy) onSubmitFields(values);
+    };
+
+    const closeOnEscape = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Escape' && !busy) {
+            event.preventDefault();
+            onClose();
+        }
+    };
+
+    const message = action.action === 'authorize' || action.action === 'device-code'
+        ? action.message
+        : null;
+    const hasForm = fields.length > 0;
+
+    return (
+        <div
+            className="provider-login-backdrop"
+            role="presentation"
+            onMouseDown={event => {
+                if (event.target === event.currentTarget && !busy) onClose();
+            }}
+        >
+            <div
+                className="provider-login-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="provider-login-title"
+                onKeyDown={closeOnEscape}
+            >
+                <header className="provider-login-header">
+                    <div>
+                        <h3 id="provider-login-title">Connect {providerName}</h3>
+                        {action.action === 'choose-method' && <p>Choose a login method.</p>}
+                        {message && <p>{message}</p>}
+                    </div>
+                    <button
+                        type="button"
+                        className="provider-login-close"
+                        onClick={onClose}
+                        disabled={busy}
+                        aria-label="Close provider login"
+                    >
+                        <i className="codicon codicon-close" />
+                    </button>
+                </header>
+
+                {action.action === 'choose-method' && (
+                    <div className="provider-login-methods">
+                        {action.methods.map(method => (
+                            <button
+                                type="button"
+                                key={method.key}
+                                onClick={() => onChooseMethod(method)}
+                                disabled={busy}
+                            >
+                                {method.label}
+                            </button>
+                        ))}
+                    </div>
+                )}
+
+                {action.action === 'device-code' && (
+                    <div className="provider-login-device-code">
+                        <span>Device code</span>
+                        <code>{action.code}</code>
+                    </div>
+                )}
+
+                {hasForm && (
+                    <form className="provider-login-form" onSubmit={submit}>
+                        {fields.map((field, index) => (
+                            <label key={field.key}>
+                                <span>{field.label}</span>
+                                <input
+                                    ref={index === 0 ? firstInputRef : undefined}
+                                    type={field.type === 'secret' ? 'password' : 'text'}
+                                    name={field.key}
+                                    value={values[field.key] ?? ''}
+                                    onChange={event => setValues(current => ({
+                                        ...current,
+                                        [field.key]: event.target.value,
+                                    }))}
+                                    autoComplete={field.type === 'secret' ? 'new-password' : 'off'}
+                                    disabled={busy}
+                                />
+                            </label>
+                        ))}
+                        <div className="provider-login-actions">
+                            <button type="button" onClick={onClose} disabled={busy}>Cancel</button>
+                            <button type="submit" className="primary" disabled={busy}>
+                                {busy ? 'Connecting…' : 'Continue'}
+                            </button>
+                        </div>
+                    </form>
+                )}
+
+                {!hasForm && action.action !== 'choose-method' && (
+                    <div className="provider-login-actions">
+                        <button type="button" className="primary" onClick={onClose} disabled={busy}>Close</button>
+                    </div>
+                )}
+
+                {error && <p className="provider-login-error" role="alert">{error}</p>}
+            </div>
+        </div>
+    );
+}

--- a/src/pages/settings/ProvidersTab.scss
+++ b/src/pages/settings/ProvidersTab.scss
@@ -137,6 +137,11 @@
       color: var(--eca-input-placeholder-fg);
     }
 
+    .provider-error {
+      font-size: 0.78em;
+      color: var(--eca-error-fg);
+    }
+
     .models-section {
       display: flex;
       flex-direction: column;

--- a/src/pages/settings/ProvidersTab.tsx
+++ b/src/pages/settings/ProvidersTab.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { webviewSend } from '../../hooks';
-import { LoginAction, ProviderAuthStatus, ProviderStatus } from '../../protocol';
+import { LoginAction, LoginMethod, ProviderAuthStatus, ProviderStatus } from '../../protocol';
 import { State, useEcaDispatch } from '../../redux/store';
+import { editorOpenUrl } from '../../redux/thunks/editor';
 import { listProviders, loginProvider, loginProviderInput, logoutProvider } from '../../redux/thunks/providers';
+import { ActiveLoginAction, ProviderLoginDialog } from './ProviderLoginDialog';
 import './ProvidersTab.scss';
 
 const authStatusLabel: Record<ProviderAuthStatus, string> = {
@@ -57,17 +58,28 @@ function authInfoText(provider: ProviderStatus): string | null {
 
 function getLoginLabel(provider: ProviderStatus): string | null {
     if (!provider.login?.methods?.length) return null;
-    const hasApiKey = provider.login.methods.some(m => m.key === 'api-key');
-    const hasOther = provider.login.methods.some(m => m.key !== 'api-key');
+    const hasApiKey = provider.login.methods.some(method => method.key === 'api-key');
+    const hasOther = provider.login.methods.some(method => method.key !== 'api-key');
     if (hasOther) return 'Login';
     if (hasApiKey) return 'Add Key';
     return 'Login';
 }
 
+function loginErrorMessage(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    if (typeof error === 'object' && error !== null && 'message' in error) {
+        const message = Reflect.get(error, 'message');
+        if (typeof message === 'string') return message;
+    }
+    return String(error);
+}
+
 function ProviderCard({ provider }: { provider: ProviderStatus }) {
     const dispatch = useEcaDispatch();
     const [modelsExpanded, setModelsExpanded] = useState(false);
-    const [loginLoading, setLoginLoading] = useState(false);
+    const [loginBusy, setLoginBusy] = useState(false);
+    const [loginAction, setLoginAction] = useState<ActiveLoginAction | null>(null);
+    const [loginError, setLoginError] = useState<string | null>(null);
 
     const auth = provider.auth;
     const isAuthed = auth.status === 'authenticated' || auth.status === 'expiring';
@@ -75,91 +87,64 @@ function ProviderCard({ provider }: { provider: ProviderStatus }) {
     const loginLabel = !isAuthed ? getLoginLabel(provider) : null;
     const info = authInfoText(provider);
 
-    const handleLoginAction = async (action: LoginAction) => {
-        if (action.action === 'choose-method') {
-            const result: string | null = await new Promise(resolve => {
-                webviewSend('editor/readInput', {
-                    title: 'Choose login method',
-                    placeholder: 'Select a method...',
-                    options: action.methods.map(m => m.label),
-                });
-                const handler = (event: MessageEvent) => {
-                    if (event.data.type === 'editor/readInputResponse') {
-                        window.removeEventListener('message', handler);
-                        resolve(event.data.data?.value ?? null);
-                    }
-                };
-                window.addEventListener('message', handler);
-            });
-            if (result) {
-                const method = action.methods.find(m => m.label === result);
-                if (method) {
-                    const nextAction = await dispatch(loginProvider({ provider: provider.id, method: method.key })).unwrap();
-                    await handleLoginAction(nextAction);
-                }
-            }
-        } else if (action.action === 'input') {
-            const data: Record<string, string> = {};
-            for (const field of action.fields) {
-                const value: string | null = await new Promise(resolve => {
-                    webviewSend('editor/readInput', {
-                        title: field.label,
-                        placeholder: `Enter ${field.label.toLowerCase()}...`,
-                        password: field.type === 'secret',
-                    });
-                    const handler = (event: MessageEvent) => {
-                        if (event.data.type === 'editor/readInputResponse') {
-                            window.removeEventListener('message', handler);
-                            resolve(event.data.data?.value ?? null);
-                        }
-                    };
-                    window.addEventListener('message', handler);
-                });
-                if (value === null) return;
-                data[field.key] = value;
-            }
-            await dispatch(loginProviderInput({ provider: provider.id, data })).unwrap();
-        } else if (action.action === 'authorize') {
-            webviewSend('editor/openUrl', { url: action.url });
-            if (action.fields?.length) {
-                const data: Record<string, string> = {};
-                for (const field of action.fields) {
-                    const value: string | null = await new Promise(resolve => {
-                        webviewSend('editor/readInput', {
-                            title: field.label,
-                            placeholder: `Enter ${field.label.toLowerCase()}...`,
-                            password: field.type === 'secret',
-                        });
-                        const handler = (event: MessageEvent) => {
-                            if (event.data.type === 'editor/readInputResponse') {
-                                window.removeEventListener('message', handler);
-                                resolve(event.data.data?.value ?? null);
-                            }
-                        };
-                        window.addEventListener('message', handler);
-                    });
-                    if (value === null) return;
-                    data[field.key] = value;
-                }
-                await dispatch(loginProviderInput({ provider: provider.id, data })).unwrap();
-            }
-        } else if (action.action === 'device-code') {
-            webviewSend('editor/openUrl', { url: action.url });
+    useEffect(() => {
+        if (isAuthed) {
+            setLoginAction(null);
+            setLoginError(null);
+        }
+    }, [isAuthed]);
+
+    const applyLoginAction = (action: LoginAction) => {
+        if (action.action === 'done') {
+            setLoginAction(null);
+            setLoginError(null);
+            void dispatch(listProviders());
+            return;
+        }
+
+        setLoginAction(action);
+        if (action.action === 'authorize' || action.action === 'device-code') {
+            void dispatch(editorOpenUrl({ url: action.url }));
         }
     };
 
-    const onLogin = async () => {
-        setLoginLoading(true);
+    const runLoginOperation = async (operation: () => Promise<LoginAction>) => {
+        setLoginBusy(true);
+        setLoginError(null);
         try {
-            const action = await dispatch(loginProvider({ provider: provider.id })).unwrap();
-            await handleLoginAction(action);
+            applyLoginAction(await operation());
+        } catch (error) {
+            setLoginError(loginErrorMessage(error));
         } finally {
-            setLoginLoading(false);
+            setLoginBusy(false);
         }
     };
 
-    const onLogout = () => {
-        dispatch(logoutProvider({ provider: provider.id }));
+    const onLogin = () => {
+        void runLoginOperation(() => dispatch(loginProvider({ provider: provider.id })).unwrap());
+    };
+
+    const onChooseMethod = (method: LoginMethod) => {
+        void runLoginOperation(() => dispatch(loginProvider({
+            provider: provider.id,
+            method: method.key,
+        })).unwrap());
+    };
+
+    const onSubmitFields = (data: Record<string, string>) => {
+        void runLoginOperation(() => dispatch(loginProviderInput({ provider: provider.id, data })).unwrap());
+    };
+
+    const onLogout = async () => {
+        setLoginBusy(true);
+        setLoginError(null);
+        try {
+            await dispatch(logoutProvider({ provider: provider.id })).unwrap();
+        } catch (error) {
+            setLoginError(loginErrorMessage(error));
+        } finally {
+            setLoginBusy(false);
+        }
     };
 
     return (
@@ -174,20 +159,21 @@ function ProviderCard({ provider }: { provider: ProviderStatus }) {
                 </div>
                 <div className="provider-actions">
                     {canLogout &&
-                        <button className="action-btn logout-btn" onClick={onLogout}>
+                        <button className="action-btn logout-btn" onClick={onLogout} disabled={loginBusy}>
                             <i className="codicon codicon-sign-out"></i>
                             Logout
                         </button>}
                     {loginLabel &&
-                        <button className="action-btn login-btn" onClick={onLogin} disabled={loginLoading}>
+                        <button className="action-btn login-btn" onClick={onLogin} disabled={loginBusy}>
                             <i className={`codicon ${loginLabel === 'Add Key' ? 'codicon-key' : 'codicon-sign-in'}`}></i>
-                            {loginLoading ? '…' : loginLabel}
+                            {loginBusy ? '…' : loginLabel}
                         </button>}
                 </div>
             </div>
 
             <div className="provider-body">
                 {info && <span className="auth-info">{info}</span>}
+                {loginError && !loginAction && <span className="provider-error" role="alert">{loginError}</span>}
 
                 {provider.models.length > 0 &&
                     <div className="models-section">
@@ -197,8 +183,8 @@ function ProviderCard({ provider }: { provider: ProviderStatus }) {
                         </button>
                         {modelsExpanded &&
                             <div className="models-list">
-                                {provider.models.map((model, i) => (
-                                    <div key={i} className="model-item">
+                                {provider.models.map(model => (
+                                    <div key={model.id} className="model-item">
                                         <span className="model-name">{model.id}</span>
                                         <div className="model-caps">
                                             {model.capabilities.reason && <span className="cap-badge">reason</span>}
@@ -211,6 +197,21 @@ function ProviderCard({ provider }: { provider: ProviderStatus }) {
                             </div>}
                     </div>}
             </div>
+
+            {loginAction && (
+                <ProviderLoginDialog
+                    providerName={provider.label || provider.id}
+                    action={loginAction}
+                    busy={loginBusy}
+                    error={loginError}
+                    onChooseMethod={onChooseMethod}
+                    onSubmitFields={onSubmitFields}
+                    onClose={() => {
+                        setLoginAction(null);
+                        setLoginError(null);
+                    }}
+                />
+            )}
         </div>
     );
 }
@@ -226,17 +227,17 @@ export function ProvidersTab() {
     }, [dispatch]);
 
     const sorted = [...providers].sort((a, b) => {
-        const priority = (p: ProviderStatus) => {
-            if (p.auth.status === 'authenticated' || p.auth.status === 'expiring') return 0;
-            if (p.auth.status === 'local') return 1;
-            if (p.configured) return 2;
+        const priority = (provider: ProviderStatus) => {
+            if (provider.auth.status === 'authenticated' || provider.auth.status === 'expiring') return 0;
+            if (provider.auth.status === 'local') return 1;
+            if (provider.configured) return 2;
             return 3;
         };
         return priority(a) - priority(b);
     });
 
-    const configured = sorted.filter(p => p.configured);
-    const unconfigured = sorted.filter(p => !p.configured);
+    const configured = sorted.filter(provider => provider.configured);
+    const unconfigured = sorted.filter(provider => !provider.configured);
 
     return (
         <div className="providers-tab">

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -679,7 +679,7 @@ export interface ProviderModel {
         webSearch: boolean;
     };
     cost?: { input: number; output: number };
-    settings?: Record<string, any>;
+    settings?: Record<string, unknown>;
 }
 
 export interface ProviderStatus {
@@ -689,7 +689,7 @@ export interface ProviderStatus {
     auth: ProviderAuth;
     login?: { methods: LoginMethod[] };
     models: ProviderModel[];
-    settings?: Record<string, any>;
+    settings?: Record<string, unknown>;
 }
 
 export interface ProvidersListResult {

--- a/src/redux/thunks/providers.ts
+++ b/src/redux/thunks/providers.ts
@@ -19,10 +19,10 @@ export const loginProvider = createAsyncThunk<LoginAction, { provider: string; m
     }
 );
 
-export const loginProviderInput = createAsyncThunk<void, { provider: string; data: Record<string, string> }, ThunkApiType>(
+export const loginProviderInput = createAsyncThunk<LoginAction, { provider: string; data: Record<string, string> }, ThunkApiType>(
     "providers/loginInput",
     async (params) => {
-        await webviewSendAndGet('providers/loginInput', params);
+        return await webviewSendAndGet('providers/loginInput', params);
     }
 );
 


### PR DESCRIPTION
> This pull request depends on the other pull request [Modernize and secure the webview toolchain](https://github.com/editor-code-assistant/eca-webview/pull/10), which must be reviewed and merged before this pull request can be accepted.

## Problem

Provider authentication in Settings was incomplete. API-key providers, Anthropic
authorization codes, OpenAI browser login, and GitHub Copilot device codes did not
share a complete dialog lifecycle, leaving several supported authentication paths
unusable from the Desktop application.

## Solution

Implement a dedicated provider authentication dialog supporting:

- API-key entry.
- Anthropic authorization-code submission.
- OpenAI browser authentication completion.
- GitHub Copilot device-code presentation.
- Explicit cancellation, busy, and error states.
- Provider refresh after successful authentication.

Preserve all existing provider protocol message names and payload shapes.

## Verification

- The isolated implementation compiled successfully with `npx tsc --noEmit`.
- The production webview build completed successfully.
- API-key, authorization-code, browser-login, device-code, cancellation, busy,
  error, and provider-update regression coverage is added by the dependent pull
  request **Enforce typed webview boundaries and add regression coverage**.
- `git diff --check` passed.